### PR TITLE
docs: fix simple typo, taks -> task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Tasks
 ---------------------------------------------------
 You can manage and debug your modules using built-in tasks. Type 'cake' at a
 bash prompt when inside your project to see available tasks and what they do.
-You can also define your own taks.
+You can also define your own task.
 
 Commands
 ---------------------------------------------------


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `task` rather than `taks`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md